### PR TITLE
RIM-162 to Standard Missile 2

### DIFF
--- a/BDArmoryExtended/Localization/localization-en-us.cfg
+++ b/BDArmoryExtended/Localization/localization-en-us.cfg
@@ -247,7 +247,7 @@ Localization
 
 
 
-	#loc_BDArmory_part_RIM_title = RIM-162 Standard Missile
+	#loc_BDArmory_part_RIM_title = RIM-66D Standard Missile 2
 	#loc_BDArmory_part_RIM_desc = A medium range multi-purpose missile for engaging both surface and air targets. Intended to be launched from a VLS launcher.
 	#loc_BDArmory_part_deployableRail = Deployable Missile Pod
 #loc_BDArmory_part_deployableReloadRail = Deployable Missile Pod (Reloading)

--- a/BDArmoryExtended/Parts/VLSQuad/Assets/RIM.cfg
+++ b/BDArmoryExtended/Parts/VLSQuad/Assets/RIM.cfg
@@ -34,7 +34,7 @@ PART
 	attachRules = 1,1,0,0,1
 	
 	// --- standard part parameters ---
-	mass = 0.312
+	mass = 0.7044
 	dragModelType = default
 	maximum_drag = 0.01
 	minimum_drag = 0.01
@@ -47,7 +47,7 @@ PART
 	MODULE
 	{
 		name = MissileLauncher
-		shortName = RIM-162
+		shortName = RIM-66D
 
 		thrust = 80 //KN thrust during boost phase
 		cruiseThrust = 45 //thrust during cruise phase
@@ -55,6 +55,10 @@ PART
 		boostTime = 6 //seconds of boost phase
 		cruiseTime = 60 //seconds of cruise phase
 		guidanceActive = true //missile has guidanceActive
+
+		useFuel = true
+  		boosterFuelMass = 0.175
+    		cruiseFuelMass = 0.105
 
 		decoupleSpeed = 10
 		decoupleForward = true
@@ -69,9 +73,22 @@ PART
 		liftArea = 0.005
 		steerMult = 6
 		maxTorque = 90
+  		gLimit = 25
+    		maxAoA = 35
 
 		missileType = missile
-		homingType = aam
+		homingType = kappa
+  		terminalHoming = true
+    		terminalHomingType = pronav
+
+		terminalHomingRange = 4000
+  		LoftMaxAltitude = 16000
+    		LoftRangeOverride = 12000
+      		LoftTermAngle = 30
+		LoftAngle = 45
+  		kappaAngle = 30
+    		pronavGain = 3
+  
 		targetingType = radar
 		activeRadarRange = 30000
 		maxOffBoresight = 90
@@ -89,7 +106,7 @@ PART
 	MODULE
 	{
 		name = BDExplosivePart
-		tntMass = 39
+		tntMass = 98
 		warheadType = Standard
 	}
 

--- a/BDArmoryExtended/Parts/VLSQuad/Assets/RIM.cfg
+++ b/BDArmoryExtended/Parts/VLSQuad/Assets/RIM.cfg
@@ -56,10 +56,6 @@ PART
 		cruiseTime = 60 //seconds of cruise phase
 		guidanceActive = true //missile has guidanceActive
 
-		useFuel = true
-  		boosterFuelMass = 0.175
-    		cruiseFuelMass = 0.105
-
 		decoupleSpeed = 10
 		decoupleForward = true
 		dropTime = 0 


### PR DESCRIPTION
- Swap RIM-162 to SM2MR and use kappa guidance
Resolves #14 